### PR TITLE
fix double upvote bug

### DIFF
--- a/public/dom.js
+++ b/public/dom.js
@@ -74,13 +74,11 @@ var DOMRender = function(sectionId, err, res) {
   };
   main.replaceChild(newResultsTable, oldResultsTable);
   //upvote hell
-  var upvoteButtons =document.getElementsByClassName('results__upvote-btn');
-  var upvoteButtonsArray = Object.keys(document.getElementsByClassName('results__upvote-btn'));
-  // Event Listener : Upvote
-  upvoteButtonsArray.forEach(function (key) {
-    upvoteButtons[key].addEventListener('mouseup', function(event) {
+  var upvoteButtons = document.getElementsByClassName('results__upvote-btn');
+  
+  for (var i = 0; i < upvoteButtons.length; i++) {
+    upvoteButtons[i].addEventListener('mouseup', function(event) {
       // dream query ?upvote=10+current=javascript
-      console.log(event);
       var resourceId = event.path[1].id.split('upvote-link-')[1];
       var currentPage = document.getElementById('drop-down-btn').textContent;
       if (currentPage==='Select Your Topic'){currentPage='Trending'};
@@ -88,10 +86,9 @@ var DOMRender = function(sectionId, err, res) {
       var buttonTopic = currentPage;
       if (currentPage==='Trending'){buttonTopic=null};
       serverRequest(idCreation, buttonTopic,'post', DOMRender);
-    })
-  })
-
-};
+    });
+  }
+}
 
 // Close the dropdown menu if the user clicks outside of it
 window.onclick = function(event) {


### PR DESCRIPTION
I just couldn't resist the temptation of a bug hunt, hope you don't mind! It was quite a juicy one :yum:

**The bug was caused by the following:**

- getElementsByClassname returns an HTML collection. According to MDN an HTML collection ['exposes its members directly as properties by both name and index'](https://developer.mozilla.org/en/docs/Web/API/HTMLCollection). Logging the ```upvoteButtons``` variable shows that each element appears twice in the HTML collection, once with the key of its class and once with the key of an index value. This is super weird as the length property does not reflect this; for example on the home page the length is 3 when on inspection it has 6 properties.
- Using ```Object.key(upvoteButtons)``` returns all the keys, for example on the home page it returns ```["0", "1", "2", "upvote-link-10", "upvote-link-2", "upvote-link-8"]```.
- As a result, iterating over the HTML collection using the result of ```Object.keys``` resulted in eventListeners being added twice, and so each click was being caught by two event listeners.

**Solution in this PR:**
It is possible to iterate over an HTML collection using a for loop. Using the length property of the HTML collection as the upper limit means that it is possible to only iterate for the actual count of the elements and so only add event listeners once. 

**Other possible solutions:**
It would also be possible to use ```Array.from``` to convert it into an array and then use ```forEach```, but ```Array.from``` is es6. Using ```call``` to apply ```forEach``` to the HTML collection is another option, but apparently it's [not so well supported](https://stackoverflow.com/a/25587133/6848825).

#53